### PR TITLE
Remove unnecessary HDF5_ROOT ifdef

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,6 @@ include            $(FRAMEWORK_DIR)/app.mk
 endif
 endif
 
-################################## OPENMC ####################################
-ifndef HDF5_ROOT
-$(error The HDF5_ROOT environment varible must be set in order to compile openmc)
-endif
-
 # Use the OPENMC submodule if it exists and OPENMC_DIR is not set
 OPENMC_SUBMODULE    := $(CURDIR)/openmc
 ifneq ($(wildcard $(OPENMC_SUBMODULE)/CMakeLists.txt),)


### PR DESCRIPTION
Cmake seems to be ignoring it, and HDF5 will now be made available
within environment's path (during a Conda build anyway...).

Cmake warning:
```pre
  command to set the policy and suppress this warning.

  Environment variable HDF5_ROOT is set to:

    /opt/civet/local/okapi/hdf5

  For compatibility, CMake is ignoring the variable.
```